### PR TITLE
Fix behaviour w/ empty list as a constant value

### DIFF
--- a/lib/unconstant.pm
+++ b/lib/unconstant.pm
@@ -91,19 +91,19 @@ sub constant_import {
 		if ($name =~ $normal_constant_name and !$forbidden{$name}) {
 			# Everything is okay
 		}
-		
+
 		# Name forced into main, but we're not in main. Fatal.
 		elsif ($forced_into_main{$name} and $pkg ne 'main') {
 			require Carp;
 			Carp::croak("Constant name '$name' is forced into main::");
 		}
-		
+
 		# Starts with double underscore. Fatal.
 		elsif ($name =~ /^__/) {
 			require Carp;
 			Carp::croak("Constant name '$name' begins with '__'");
 		}
-		
+
 		# Maybe the name is tolerable
 		elsif ($name =~ $tolerable) {
 			# Then we'll warn only if you've asked for warnings
@@ -160,7 +160,7 @@ sub constant_import {
 			$flush_mro->{$pkg}++;
 		}
 		else {
-			die 'should never hit this';
+			*$full_name = sub () { };
 		}
 	}
 	# Flush the cache exactly once if we make any direct symbol table changes.

--- a/t/03_list.t
+++ b/t/03_list.t
@@ -1,4 +1,4 @@
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 package Foo1 {
 	use constant BAR => (1,2,3,4);
@@ -37,6 +37,20 @@ BEGIN {
 	is( Foo3::baz, 5, 'Constant length set right initially' );
 	*Foo3::BAR = sub { 42 };
 	is( Foo3::baz, 5, 'Constant are inlined again after use of [no constant]' );
+}
+
+package Foo4 {
+	use unconstant;
+	use constant BAR => ();
+	use constant BAZ => undef;
+	sub bar { BAR }
+	sub baz { BAZ }
+}
+
+BEGIN {
+	no warnings 'redefine';
+	is( Foo4::bar, undef, 'Empty list as a constant value is hadled correctly' );
+	is( Foo4::baz, undef, 'undef as a constant value is hadled correctly' );
 }
 
 1;


### PR DESCRIPTION
[This line in core constant.pm](https://github.com/Perl/perl5/blob/d9bfa782f8cc54abdbea9c0a91d1b25a9ab98736/dist/constant/lib/constant.pm#L192) handles the case when the constant value is an empty list; `unconstant.pm` used to die in this case, which is wrong. This pull request fixes this behaviour.

Also removes some extra tabs on empty lines.